### PR TITLE
Fixed invalid encoding on Python 3

### DIFF
--- a/base64image/base64image.py
+++ b/base64image/base64image.py
@@ -53,8 +53,12 @@ class Base64Image(object):
 
         """
 
-        data_uri = ("data:image/%s;base64,%s"
-                    % (self.image_format, self.base64_image_string))
+        if type(self.base64_image_string) is bytes:
+            content = self.base64_image_string.decode()
+        else:
+            content = self.base64_image_string
+
+        data_uri = ("data:image/%s;base64,%s" % (self.image_format, content))
         return data_uri
 
     @staticmethod


### PR DESCRIPTION
Result of `base64.b64encode()` in Python 3 it is bytes (not string) and this reason of invalid encoding.

This fix simply generates the result string more correctly.

Before:
```
data:image/png;base64,b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY2BgYAAAAAQAAVzN/2kAAAAASUVORK5CYII='
```

After:
```
data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY2BgYAAAAAQAAVzN/2kAAAAASUVORK5CYII=
```
